### PR TITLE
Add support for async def-style coroutine function definitions

### DIFF
--- a/pythonx/pythonhelper.py
+++ b/pythonx/pythonhelper.py
@@ -113,7 +113,7 @@ class SimplePythonTagsParser(object):
     # regexp used to extract a class name
     CLASS_RE                    = re.compile('class[ \t]+([^(:]+).*')
     # regexp used to extract a method or function name
-    METHOD_RE                   = re.compile('def[ \t]+([^(]+).*')
+    METHOD_RE                   = re.compile('(?:async\s*)?def[ \t]+([^(]+).*')
 
     # }}}
 


### PR DESCRIPTION
Simple regex modification, otherwise Python 3.5+ `async def` coroutine functions were just ignored. 

It's working well on my end. Thanks for supporting this handy vim plugin.